### PR TITLE
Make evil-search-highlight-persist face match isearch

### DIFF
--- a/ample-theme.el
+++ b/ample-theme.el
@@ -119,6 +119,7 @@
    ;; search
    `(isearch		((t (:background ,ample/blue :foreground ,ample/bg))))
    `(lazy-highlight	((t (:background ,ample/bg :foreground ,ample/purple :underline t))))
+   `(evil-search-highlight-persist-highlight-face ((t (:background ,ample/blue :foreground ,ample/bg))))
 
    ;; ace-jump
    `(ace-jump-face-background ((t (:inherit font-lock-comment-face))))


### PR DESCRIPTION
Adds a more consistent face for `evil-search-highlight-persist`, which was defaulting to an unreadable yellow for me. I used the same face as the isearch face for this