### PR TITLE
guide-key support

### DIFF
--- a/ample-theme.el
+++ b/ample-theme.el
@@ -687,6 +687,11 @@
    `(font-latex-superscript-face          ((t (:height 0.8))))
    `(font-latex-warning-face              ((t (:inherit font-lock-warning-face))))
 
+   ;; guide-key
+   `(guide-key/prefix-command-face    ((t (:foreground ,ample/green))))
+   `(guide-key/highlight-command-face ((t (:foreground ,ample/blue))))
+   `(guide-key/key-face               ((t (:foreground ,ample/gray))))
+
    ) ;; end of custom-theme-set-faces
 
   (custom-theme-set-variables


### PR DESCRIPTION
Here's one for `guide-key` and a picture in case you don't use it

![ample-guide-key](https://cloud.githubusercontent.com/assets/2208382/7655842/740dc75e-faf4-11e4-9412-236db05fd098.PNG)
