### PR TITLE
Add link face

### DIFF
--- a/ample-flat-theme.el
+++ b/ample-flat-theme.el
@@ -85,6 +85,7 @@
    `(default ((t (:foreground ,ample/fg :background ,ample/bg))))
    `(cursor  ((t (:foreground ,ample/bg :background ,ample/cursor))))
    `(fringe  ((t (:background ,ample/fringe))))
+   `(link    ((t (:foreground ,ample/lighter-blue :underline t))))
    `(region  ((t (:background ,ample/region))))
 
    ;; standard font lock

--- a/ample-light-theme.el
+++ b/ample-light-theme.el
@@ -91,6 +91,7 @@
    `(default ((t (:foreground ,ample/fg :background ,ample/bg))))
    `(cursor  ((t (:foreground ,ample/bg :background ,ample/cursor))))
    `(fringe  ((t (:background ,ample/fringe))))
+   `(link    ((t (:foreground ,ample/lighter-blue :underline t))))
    `(region  ((t (:background ,ample/region))))
 
    ;; standard font lock

--- a/ample-theme.el
+++ b/ample-theme.el
@@ -87,6 +87,7 @@
    `(default ((t (:foreground ,ample/fg :background ,ample/bg))))
    `(cursor  ((t (:foreground ,ample/bg :background ,ample/cursor))))
    `(fringe  ((t (:background ,ample/fringe))))
+   `(link    ((t (:foreground ,ample/lighter-blue :underline t))))
    `(region  ((t (:background ,ample/region))))
 
    ;; standard font lock


### PR DESCRIPTION
I don't care too much what color you pick, but I'd like the link face to be defined because it defaults to cyan, which doesn't fit with the theme well. At least paradox and org-mode use this face.