### PR TITLE
Term faces

### DIFF
--- a/ample-flat-theme.el
+++ b/ample-flat-theme.el
@@ -156,6 +156,18 @@
    ;; shell
    `(comint-highlight-prompt ((t (:foreground ,ample/green))))
 
+    ;; term 
+   `(term-color-black ((t (:foreground ,ample/darkest-gray :background ,ample/darkest-gray))))
+   `(term-color-red ((t (:foreground ,ample/red :background ,ample/red))))
+   `(term-color-green ((t (:foreground ,ample/green :background ,ample/green))))
+   `(term-color-yellow ((t (:foreground ,ample/yellow :background ,ample/yellow))))
+   `(term-color-blue ((t (:foreground ,ample/blue :background ,ample/blue))))
+   `(term-color-magenta ((t (:foreground ,ample/purple :background ,ample/purple))))
+   `(term-color-cyan ((t (:foreground ,ample/lighter-blue :background ,ample/lighter-blue))))
+   `(term-color-white ((t (:foreground ,ample/fg :background ,ample/fg))))
+   `(term-default-fg-color ((t (:inherit ample/fg))))
+   `(term-default-bg-color ((t (:inherit ample/bg))))
+   
    ;; erc
    `(erc-nick-default-face ((t (:foreground ,ample/blue))))
    `(erc-my-nick-face ((t (:foreground ,ample/yellow))))

--- a/ample-light-theme.el
+++ b/ample-light-theme.el
@@ -161,6 +161,18 @@
    ;; shell
    `(comint-highlight-prompt ((t (:foreground ,ample/green))))
 
+   ;; term 
+   `(term-color-black ((t (:foreground ,ample/darkest-gray :background ,ample/darkest-gray))))
+   `(term-color-red ((t (:foreground ,ample/red :background ,ample/red))))
+   `(term-color-green ((t (:foreground ,ample/green :background ,ample/green))))
+   `(term-color-yellow ((t (:foreground ,ample/yellow :background ,ample/yellow))))
+   `(term-color-blue ((t (:foreground ,ample/blue :background ,ample/blue))))
+   `(term-color-magenta ((t (:foreground ,ample/purple :background ,ample/purple))))
+   `(term-color-cyan ((t (:foreground ,ample/lighter-blue :background ,ample/lighter-blue))))
+   `(term-color-white ((t (:foreground ,ample/fg :background ,ample/fg))))
+   `(term-default-fg-color ((t (:inherit ample/fg))))
+   `(term-default-bg-color ((t (:inherit ample/bg))))
+
    ;; erc
    `(erc-nick-default-face ((t (:foreground ,ample/blue))))
    `(erc-my-nick-face ((t (:foreground ,ample/yellow))))

--- a/ample-theme.el
+++ b/ample-theme.el
@@ -165,6 +165,18 @@
    ;; shell
    `(comint-highlight-prompt ((t (:foreground ,ample/green))))
 
+   ;; term 
+   `(term-color-black ((t (:foreground ,ample/darkest-gray :background ,ample/darkest-gray))))
+   `(term-color-red ((t (:foreground ,ample/red :background ,ample/red))))
+   `(term-color-green ((t (:foreground ,ample/green :background ,ample/green))))
+   `(term-color-yellow ((t (:foreground ,ample/yellow :background ,ample/yellow))))
+   `(term-color-blue ((t (:foreground ,ample/blue :background ,ample/blue))))
+   `(term-color-magenta ((t (:foreground ,ample/purple :background ,ample/purple))))
+   `(term-color-cyan ((t (:foreground ,ample/lighter-blue :background ,ample/lighter-blue))))
+   `(term-color-white ((t (:foreground ,ample/fg :background ,ample/fg))))
+   `(term-default-fg-color ((t (:inherit ample/fg))))
+   `(term-default-bg-color ((t (:inherit ample/bg))))
+
    ;; erc
    `(erc-nick-default-face ((t (:foreground ,ample/blue))))
    `(erc-my-nick-face ((t (:foreground ,ample/yellow))))


### PR DESCRIPTION
# Add ansi-term faces
Add ansi-term faces for all of the themes.

## Changes
Below shows how the themes look without the changes (```Old```) and with the changes (```New```)

### Ample theme
#### Old
![old-ample-theme](https://cloud.githubusercontent.com/assets/849609/21150208/2909997c-c12c-11e6-9eed-b5c0b356b17c.png)

#### New
![ample-theme-new](https://cloud.githubusercontent.com/assets/849609/21150187/1529b752-c12c-11e6-8d2c-d682da7b6fb8.png)

### Ample light theme
#### Old
![ample-light-theme-light](https://cloud.githubusercontent.com/assets/849609/21150218/31b6dbb6-c12c-11e6-9edc-255cfa188e2d.png)

#### New
![ample-light-theme-new](https://cloud.githubusercontent.com/assets/849609/21150222/34cac1f0-c12c-11e6-987b-602faa965f06.png)

### Ample flat theme
#### Old
![ample-flat-theme-old](https://cloud.githubusercontent.com/assets/849609/21150226/3a3ba4ec-c12c-11e6-9635-e8a02572b04b.png)

#### New
![ample-flat-theme-new](https://cloud.githubusercontent.com/assets/849609/21150231/3e133314-c12c-11e6-8e09-c0176876be7e.png)


