### PR TITLE
#a74604 for region background

### DIFF
--- a/ample-flat-theme.el
+++ b/ample-flat-theme.el
@@ -67,7 +67,7 @@
 
       (ample/cursor "#afffef")
       (ample/fringe "#262424")
-      (ample/region "#343030")
+      (ample/region "#a74604")
 
       (ample/rb0 "#b1b0e3")
       (ample/rb1 "#a58585")


### PR DESCRIPTION
currently, when highlighting single words, one can barely recognise the highlighted region
how about http://www.color-hex.com/color/a74604 ?