### PR TITLE
Try boxed for enabled/disable face attributes

### DIFF
--- a/ample-flat-theme.el
+++ b/ample-flat-theme.el
@@ -785,8 +785,8 @@
    `(realgud-overlay-arrow3         ((t (:foreground ,ample/orange))))
    `(realgud-bp-enabled-face        ((t (:inherit error))))
    `(realgud-bp-disabled-face       ((t (:foreground ,ample/dark-gray))))
-   `(realgud-bp-line-enabled-face   ((t (:underline ,ample/red))))
-   `(realgud-bp-line-disabled-face  ((t (:underline ,ample/dark-gray))))
+   `(realgud-bp-line-enabled-face   ((t (:box (:color ,ample/red)))))
+   `(realgud-bp-line-disabled-face  ((t (:box (:color "grey50")))))
    `(realgud-line-number            ((t (:foreground ,ample/yellow))))
    `(realgud-backtrace-number       ((t (:foreground ,ample/yellow, :weight bold))))
 

--- a/ample-light-theme.el
+++ b/ample-light-theme.el
@@ -757,8 +757,8 @@
    `(realgud-overlay-arrow3         ((t (:foreground ,ample/orange))))
    `(realgud-bp-enabled-face        ((t (:inherit error))))
    `(realgud-bp-disabled-face       ((t (:foreground ,ample/dark-gray))))
-   `(realgud-bp-line-enabled-face   ((t (:underline ,ample/red))))
-   `(realgud-bp-line-disabled-face  ((t (:underline ,ample/dark-gray))))
+   `(realgud-bp-line-enabled-face   ((t (:box (:color ,ample/red)))))
+   `(realgud-bp-line-disabled-face  ((t (:box (:color "grey50")))))
    `(realgud-line-number            ((t (:foreground ,ample/yellow))))
    `(realgud-backtrace-number       ((t (:foreground ,ample/yellow, :weight bold))))
 

--- a/ample-theme.el
+++ b/ample-theme.el
@@ -822,8 +822,8 @@
    `(realgud-overlay-arrow3         ((t (:foreground ,ample/orange))))
    `(realgud-bp-enabled-face        ((t (:inherit error))))
    `(realgud-bp-disabled-face       ((t (:foreground ,ample/dark-gray))))
-   `(realgud-bp-line-enabled-face   ((t (:underline ,ample/red))))
-   `(realgud-bp-line-disabled-face  ((t (:underline ,ample/dark-gray))))
+   `(realgud-bp-line-enabled-face   ((t (:box (:color ,ample/red)))))
+   `(realgud-bp-line-disabled-face  ((t (:box (:color "grey50")))))
    `(realgud-line-number            ((t (:foreground ,ample/yellow))))
    `(realgud-backtrace-number       ((t (:foreground ,ample/yellow, :weight bold))))
 


### PR DESCRIPTION
Perhaps a boxed face would be better for enabled and disabled breakpoints? What do you think? 

![ample-boxed](https://user-images.githubusercontent.com/8851/34951154-53d5727a-f9e3-11e7-9f30-dda906fb7c88.png)

(Sorry for the futzing)